### PR TITLE
fix: swagger readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker-compose up
 ./mvnw spring-boot:run
 
 # access the api documentation
-http://localhost:8080/swagger-ui.html 
+http://localhost:8080/swagger-ui/index.html 
 ```
 
 # Author


### PR DESCRIPTION
The swagger README link points to a protected URL, changed it to /swagger-ui/index.html, and now matching Spring Security Filter Chain definition

```java
authorizeHttpRequests.requestMatchers("/swagger-ui/**").permitAll()
``` 